### PR TITLE
nat data to aoi edits

### DIFF
--- a/R/natdata_to_aoi.R
+++ b/R/natdata_to_aoi.R
@@ -36,14 +36,15 @@ library(prioritizr)
 library(sp)
 library(stringr)
 library(gdalUtilities) 
-source("R/fct_matrix_intersect.R")
-source("R/fct_matrix_to_raster.R")
+source("R/fct_matrix_intersect.R") # <--- CHANGE IF NOT RUNNING SCRIPT FROM GITHUB FOLDER
+source("R/fct_matrix_to_raster.R") # <--- CHANGE IF NOT RUNNING SCRIPT FROM GITHUB FOLDER
 
 # 2.0 Set up -------------------------------------------------------------------
 
 ## Set output folder and AOI ----
 root_folder <- "data/output" # <--- CHANGE HERE FOR NEW PROJECT
 aoi_path <- "data/aoi/AOI.tif" # <--- CHANGE HERE FOR NEW AOI
+nat_data_path <- "data" # <--- CHANGE IF NOT RUNNING SCRIPT FROM GITHUB FOLDER
 
 ## Create output folder directory ----
 dir.create(file.path(root_folder, "Variables"))
@@ -66,7 +67,7 @@ dir.create(file.path(root_folder, "Variables", "Themes", "NSC_SAR"))
 dir.create(file.path(root_folder, "Variables", "Themes", "NSC_SPP"))
 
 # Copy / paste LUT ----
-LUT <- list.files("data/national/species", pattern='.xlsx$|.csv$', full.names = T)
+LUT <- list.files(file.path(nat_data_path, "/national/species"), pattern='.xlsx$|.csv$', full.names = T)
 file.copy(LUT, file.path(root_folder, "Variables", "_Tables"))
 
 ## Read-in area of interest .tiff (aoi) ----
@@ -76,12 +77,11 @@ aoi_1km0 <- aoi_1km
 aoi_1km0[aoi_1km0 == 1] <- 0
 
 ## Read-in national 1km grid (all of Canada) ----
-ncc_1km <- raster("data/national/_nccgrid/NCC_PU.tif")
+ncc_1km <- raster(file.path(nat_data_path, "national/_nccgrid/NCC_PU.tif"))
 ncc_1km_idx <- ncc_1km
 ncc_1km_idx[] <- 1:ncell(ncc_1km_idx) # 267,790,000 available planning units
 
 ## Align aoi to same extent and same number of rows/cols as national grid ----
-unlink("data/aoi/align/*", recursive = T, force = T) # clear folder
 ### get spatial properties of ncc grid
 proj4_string <- sp::proj4string(ncc_1km) # projection string
 bbox <- raster::bbox(ncc_1km) # bounding box
@@ -90,86 +90,86 @@ te <- c(bbox[1,1], bbox[2,1], bbox[1,2], bbox[2,2]) # xmin, ymin, xmax, ymax
 ts <- c(raster::ncol(ncc_1km), raster::nrow(ncc_1km)) # ncc grid: columns/rows
 ### gdalUtilities::gdalwarp does not require a local GDAL installation ----
 gdalUtilities::gdalwarp(srcfile = aoi_path,
-                        dstfile = paste0("data/aoi/align/", aoi_name, ".tif"),
+                        dstfile = paste0(tools::file_path_sans_ext(aoi_path), "_align.tif"),
                         te = te,
                         t_srs = proj4_string,
                         ts = ts,
                         overwrite = TRUE)
 
 ## Get aligned AOI planning units ---- 
-aoi_pu <- raster(paste0("data/aoi/align/", aoi_name, ".tif"))
+aoi_pu <- raster(paste0(tools::file_path_sans_ext(aoi_path), "_align.tif"))
 # Create aoi_rij matrix: 11,010,932 planing units activated 
-aoi_rij <- prioritizr::rij_matrix(ncc_1km, stack(aoi_pu, ncc_1km_idx)) 
+aoi_rij <- prioritizr::rij_matrix(ncc_1km, stack(aoi_pu, ncc_1km_idx))
 rownames(aoi_rij) <- c("AOI", "Idx")
 
 # 3.0 Extract species to aoi ---------------------------------------------------
 
 ## ECCC Critical Habitat (theme) ----
-natdata_rij <- readRDS("data/national/species/rij_ECCC_CH.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_ECCC_CH.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
-matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0, 
-  paste0(root_folder, "/Variables/Themes/ECCC_CH"), "T_ECCC_CH_", "INT1U")
+matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
+                 paste0(root_folder, "/Variables/Themes/ECCC_CH"), "T_ECCC_CH_", "INT1U")
 
 ## ECCC Species at risk (theme) ----
-natdata_rij <- readRDS("data/national/species/rij_ECCC_SAR.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_ECCC_SAR.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
-matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0, 
-  paste0(root_folder, "/Variables/Themes/ECCC_SAR"), "T_ECCC_SAR_", "INT1U")
+matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
+                 paste0(root_folder, "/Variables/Themes/ECCC_SAR"), "T_ECCC_SAR_", "INT1U")
 
 ## IUCN Amphibians (theme) ----
-natdata_rij <- readRDS( "data/national/species/rij_IUCN_AMPH.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_IUCN_AMPH.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/IUCN_AMPH"), "T_IUCN_AMPH_", "INT1U")
+                 paste0(root_folder, "/Variables/Themes/IUCN_AMPH"), "T_IUCN_AMPH_", "INT1U")
 
 ## IUCN Birds (theme) ----
-natdata_rij <- readRDS( "data/national/species/rij_IUCN_BIRD.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_IUCN_BIRD.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/IUCN_BIRD"), "T_IUCN_BIRD_", "INT1U")
+                 paste0(root_folder, "/Variables/Themes/IUCN_BIRD"), "T_IUCN_BIRD_", "INT1U")
 
 ## IUCN Mammals (theme) ----
-natdata_rij <- readRDS( "data/national/species/rij_IUCN_MAMM.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_IUCN_MAMM.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/IUCN_MAMM"), "T_IUCN_MAMM_", "INT1U")
+                 paste0(root_folder, "/Variables/Themes/IUCN_MAMM"), "T_IUCN_MAMM_", "INT1U")
 
 ## IUCN Reptiles (theme) ----
-natdata_rij <- readRDS( "data/national/species/rij_IUCN_REPT.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_IUCN_REPT.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/IUCN_REPT"), "T_IUCN_REPT_", "INT1U")
+                 paste0(root_folder, "/Variables/Themes/IUCN_REPT"), "T_IUCN_REPT_", "INT1U")
 
 ## Nature Serve Canada Endemics (theme) ----
-natdata_rij <- readRDS( "data/national/species/rij_NSC_END.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_NSC_END.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/NSC_END"), "T_NSC_END_", "INT1U")
+                 paste0(root_folder, "/Variables/Themes/NSC_END"), "T_NSC_END_", "INT1U")
 
 ## Nature Serve Canada Species at risk (theme) ----
-natdata_rij <- readRDS( "data/national/species/rij_NSC_SAR.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_NSC_SAR.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/NSC_SAR"), "T_NSC_SAR_", "INT1U")
+                 paste0(root_folder, "/Variables/Themes/NSC_SAR"), "T_NSC_SAR_", "INT1U")
 
 ## Nature Serve Canada Common Species (theme) ----
-natdata_rij <- readRDS( "data/national/species/rij_NSC_SPP.rds")
+natdata_rij <- readRDS(file.path(nat_data_path, "national/species/rij_NSC_SPP.rds"))
 matrix_overlap <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/NSC_SPP"), "T_NSC_SPP_", "INT1U")
+                 paste0(root_folder, "/Variables/Themes/NSC_SPP"), "T_NSC_SPP_", "INT1U")
 
 # 4.0 Extract conservation variables to aoi ------------------------------------
 
 ## Forest - LC (theme) ----
-natdata_r <- raster("data/national/forest/FOREST_LC_COMPOSITE_1KM.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/forest/FOREST_LC_COMPOSITE_1KM.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Forest-lc")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "INT2U")
+                 paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "INT2U")
 
 ## Forest - LU (theme) ----
-natdata_r <- raster("data/national/forest/FOREST_LU_COMPOSITE_1KM.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/forest/FOREST_LU_COMPOSITE_1KM.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Forest-lu")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
@@ -177,79 +177,79 @@ matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
                  paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "INT2U")
 
 ## Grassland (theme) ----
-natdata_r <- raster("data/national/grassland/Grassland_AAFC_LUTS_Total_Percent.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/grassland/Grassland_AAFC_LUTS_Total_Percent.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Grassland")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "INT2U")
+                 paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "INT2U")
 
 ## Lakes (theme) ----
-natdata_r <- raster("data/national/water/Lakes_CanVec_50k_ha.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/water/Lakes_CanVec_50k_ha.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Lakes")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "FLT4S")
+                 paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "FLT4S")
 
 ## River length (theme) ----
-natdata_r <- raster("data/national/water/grid_1km_water_linear_flow_length_1km.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/water/grid_1km_water_linear_flow_length_1km.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("River_length")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/KM"), "T_KM_", "FLT4S")
+                 paste0(root_folder, "/Variables/Themes/KM"), "T_KM_", "FLT4S")
 
 ## Shoreline (theme) ----
-natdata_r <- raster("data/national/water/Shoreline.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/water/Shoreline.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Shoreline_length")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/KM"), "T_KM_", "FLT4S")
+                 paste0(root_folder, "/Variables/Themes/KM"), "T_KM_", "FLT4S")
 
 ## Wetlands (theme) ----
-natdata_r <- raster("data/national/wetlands/Wetland_comb_proj_diss_90m_Arc.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/wetlands/Wetland_comb_proj_diss_90m_Arc.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Wetlands")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "FLT4S")
+                 paste0(root_folder, "/Variables/Themes/LC"), "T_LC_", "FLT4S")
 
 ## Carbon storage (weight) ----
-natdata_r <- raster("data/national/carbon/Carbon_Mitchell_2021_t.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/carbon/Carbon_Mitchell_2021_t.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Carbon_storage")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Carbon potential (weight) ----
-natdata_r <- raster("data/national/carbon/Carbon_Potential_NFI_2011_CO2e_t_year.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/carbon/Carbon_Potential_NFI_2011_CO2e_t_year.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Carbon_potential")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Climate forward velocity (weight) ----
-natdata_r <- raster("data/national/climate/fwdshortestpath.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/climate/fwdshortestpath.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Climate_forward_velocity")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Climate refugia (weight) ----
-natdata_r <- raster("data/national/climate/NA_combo_refugia_sum45.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/climate/NA_combo_refugia_sum45.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Climate_refugia")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Climate extremes (weight) ----
-natdata_r <- raster("data/national/climate/Climate_LaSorte_ExtremeHeatEvents.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/climate/Climate_LaSorte_ExtremeHeatEvents.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Climate_extremes")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
@@ -257,7 +257,7 @@ matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
                  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Connectivity (weight) ----
-natdata_r <- raster("data/national/connectivity/Connectivity_Pither_Current_Density.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/connectivity/Connectivity_Pither_Current_Density.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Connectivity")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
@@ -265,30 +265,30 @@ matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
                  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Human footprint (weight) ----
-natdata_r <- raster("data/national/disturbance/CDN_HF_cum_threat_20221031_NoData.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/disturbance/CDN_HF_cum_threat_20221031_NoData.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Human_footprint")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## KBAs (weight) ----
-natdata_r <- raster("data/national/kba/KBA.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/kba/KBA.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Key_biodiversity_areas")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Protected (include) ----
 ### canadian protected and conserved areas database (CPCAD)
-CPCAD <- raster("data/national/protected/CPCAD.tif")
+CPCAD <- raster(file.path(nat_data_path, "national/protected/CPCAD.tif"))
 CPCAD[is.na(CPCAD[])] <- 0 # convert na values to 0
 ### NCC direct properties
-NCC_direct <- raster("data/national/protected/NCC_direct.tif")
+NCC_direct <- raster(file.path(nat_data_path, "national/protected/NCC_direct.tif"))
 NCC_direct[is.na(NCC_direct[])] <- 0 
 ### NCC indirect properties
-NCC_indirect <- raster("data/national/protected/NCC_indirect.tif") 
+NCC_indirect <- raster(file.path(nat_data_path, "national/protected/NCC_indirect.tif"))
 NCC_indirect[is.na(NCC_indirect[])] <- 0 
 ### raster math
 CPCAD_NCC <- CPCAD + NCC_direct + NCC_indirect
@@ -298,26 +298,26 @@ natdata_rij <- prioritizr::rij_matrix(ncc_1km, CPCAD_NCC)
 rownames(natdata_rij) <- c("Protected")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Includes"), "I_", "INT1U")
+                 paste0(root_folder, "/Variables/Includes"), "I_", "INT1U")
 ### remove objects to save RAM
 rm(CPCAD, NCC_direct, NCC_indirect)
 gc()
 
 ## Recreation (weight) ----
-natdata_r <- raster("data/national/recreation/rec_pro_1a_norm.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/recreation/rec_pro_1a_norm.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Recreation")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 ## Freshwater (weight) ----
-natdata_r <- raster("data/national/water/water_provision_2a_norm.tif")
+natdata_r <- raster(file.path(nat_data_path, "national/water/water_provision_2a_norm.tif"))
 natdata_rij <- prioritizr::rij_matrix(ncc_1km, natdata_r)
 rownames(natdata_rij) <- c("Freshwater")
 matrix_overlap  <- matrix_intersect(natdata_rij, aoi_rij) 
 matrix_to_raster(ncc_1km_idx, matrix_overlap, aoi_1km0,
-  paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
+                 paste0(root_folder, "/Variables/Weights"), "W_", "FLT4S")
 
 # Clear some RAM if possible
 gc()


### PR DESCRIPTION
Proposed edits to make all paths relative to those set in the script header. This will allow the script to run from either: 
1. the github repo folder, referencing the national data added in repo/data (previous behavior, currently set as the default), or 
2. the script could be copied to the project folder and the national data can be stored locally and referenced with a file path. 
    - This is how I've set up my project so I can have a record of all scripts in the project folder. It also means the national data can be stored locally in the DATA folder along with all other master data sets. For sharing with non-dev users, we can still send them the data and tell them to drop it in the repo/data folder as we do currently.
  
Changes to the script:
- Added object for path to data folder, and replaced all hard coded data paths to use this object path.
- Fixed some new line errors. The matrix_to_raster() call was giving me an error when using ctrl+A to run the entire script, but not when that line was run individually. I think this is caused by a non-standard new line, possibly copied in from another text editor.
- Save aligned AOI to the project AOI folder instead of the github repo. Previously the aligned aoi from gdalwarp() was saved into the repo/data folder. I think it makes sense to keep this with the original AOI.tif. This avoids having any project specific data saved in the repo folder, and also means the aligned aoi does not have to be deleted every time the script it run.